### PR TITLE
Fix pgboucnerconfig

### DIFF
--- a/src/api/organization/project/branch/__init__.py
+++ b/src/api/organization/project/branch/__init__.py
@@ -1801,7 +1801,7 @@ async def update_pgbouncer_config(
     host = _pgbouncer_host_for_namespace(namespace)
     update_commands = parameters.model_dump(exclude_defaults=True)
 
-    config_map_name = f"{vmi_name}-pgbouncer"
+    config_map_name = f"{vmi_name}-config"
     try:
         await _update_pgbouncer_config_map(
             namespace=namespace,


### PR DESCRIPTION
Fixes: https://github.com/simplyblock/vela/issues/315
PGBouncer configuration is stored at `"{vmi_name}-config"` and is present in `pgbouncer.ini` file of the same configmap. 

`
"level": "INFO", "logger": "uvicorn.access", "message": "10.244.5.195:34246 - \"PATCH /organizations/01KP2P7J4VXA6ENZT7MWEXTS62/projects/01KP2P7W7WVHD22DKTFYPZDQBH/branches/01KP2P8HK4CTR0XS21JK14560X/pgbouncer-config HTTP/1.1\" 200"}
`

### testing

have updated default pool size from UI

the API request was successfully
```
{"timestamp": "2026-04-13T05:53:33+0000", "level": "INFO", "logger": "uvicorn.access", "message": "10.244.5.195:34246 - \"PATCH /organizations/01KP2P7J4VXA6ENZT7MWEXTS62/projects/01KP2P7W7WVHD22DKTFYPZDQBH/branches/01KP2P8HK4CTR0XS21JK14560X/pgbouncer-config HTTP/1.1\" 200"}
```

and the configmap is also updated successfully. 
```
    default_pool_size = 40
```

and the the response of https://<endpoint>/api/platform/organizations/<orgid>/projects/<pid>/branches/<branch-id>/pgbouncer

also shows the updated value
```
{
    "pgbouncer_enabled": true,
    "pool_mode": "transaction",
    "max_client_conn": 100,
    "default_pool_size": 40,
    "server_idle_timeout": 60,
    "server_lifetime": 600,
    "query_wait_timeout": 30,
    "reserve_pool_size": 0
}
```

### additional notes

Tests failures are not related to the fix in this PR

```
tests/branches/test_start_stop.py::test_branch_stop FAILED               [ 97%]
tests/branches/test_start_stop.py::test_branch_start FAILED              [100%]
```
