### PR TITLE
pgbouncer config: auth_type = scram-sha-256

### DIFF
--- a/src/deployment/charts/vela/templates/autoscaler/config.yaml
+++ b/src/deployment/charts/vela/templates/autoscaler/config.yaml
@@ -53,7 +53,7 @@ data:
     client_tls_key_file = /vela/certs/tls.key
     client_tls_cert_file = /vela/certs/tls.crt
     client_tls_ca_file = /vela/certs/tls.crt
-    auth_type = plain
+    auth_type = scram-sha-256
     auth_file = /vela/config/users.txt
     auth_user = vela
     auth_query = SELECT * FROM pgbouncer.get_auth($1)


### PR DESCRIPTION

```
SELECT usename, left(passwd,40) FROM pg_shadow WHERE usename='postgres';
```

-output
```
 usename  |                   left                   
----------+------------------------------------------
 postgres | SCRAM-SHA-256$4096:I+0OUdUjJqetAxwCtY3dN
(1 row)
```

postgres has a `SCRAM-SHA-256` hash, but pgbouncer_pg18.ini uses auth_type = plain, which can't verify SCRAM passwords from auth_query.
